### PR TITLE
make sure object is string before using color method

### DIFF
--- a/lib/sensu-cli/sensu.rb
+++ b/lib/sensu-cli/sensu.rb
@@ -151,7 +151,7 @@ module SensuCli
                 puts "#{key}:  ".color(:cyan) + "#{value}".color(:green)
               end
             else
-              puts item.color(:cyan)
+              puts item.to_s.color(:cyan)
             end
           end
         end


### PR DESCRIPTION
or experience this grace

<pre>
#sensu aggregate show system_git_revision
-------
/var/lib/gems/1.9.1/gems/sensu-cli-0.0.7/lib/sensu-cli/sensu.rb:154:in `block in pretty': undefined method `color' for 1367335132:Fixnum (NoMethodError)
        from /var/lib/gems/1.9.1/gems/sensu-cli-0.0.7/lib/sensu-cli/sensu.rb:147:in `each'
        from /var/lib/gems/1.9.1/gems/sensu-cli-0.0.7/lib/sensu-cli/sensu.rb:147:in `pretty'
        from /var/lib/gems/1.9.1/gems/sensu-cli-0.0.7/lib/sensu-cli/sensu.rb:114:in `make_call'
        from /var/lib/gems/1.9.1/gems/sensu-cli-0.0.7/lib/sensu-cli/sensu.rb:27:in `setup'
        from /var/lib/gems/1.9.1/gems/sensu-cli-0.0.7/bin/sensu:8:in `<top (required)>'
        from /usr/local/bin/sensu:23:in `load'
        from /usr/local/bin/sensu:23:in `<main>'
</pre>
