### PR TITLE
Allow specifying a http proxy in the settings file

### DIFF
--- a/lib/sensu-cli/api.rb
+++ b/lib/sensu-cli/api.rb
@@ -5,7 +5,8 @@ require 'rainbow/ext/string'
 module SensuCli
   class Api
     def request(opts)
-      http = Net::HTTP.new(opts[:host], opts[:port])
+      http = Net::HTTP.new(opts[:host], opts[:port], opts[:proxy_address],
+                           opts[:proxy_port])
       http.read_timeout = opts[:read_timeout]
       http.open_timeout = opts[:open_timeout]
       if opts[:ssl]

--- a/lib/sensu-cli/base.rb
+++ b/lib/sensu-cli/base.rb
@@ -39,7 +39,9 @@ module SensuCli
         :user => Config.user || nil,
         :read_timeout => Config.read_timeout || 15,
         :open_timeout => Config.open_timeout || 5,
-        :password => Config.password || nil
+        :password => Config.password || nil,
+        :proxy_address => Config.proxy_address || :ENV,
+        :proxy_port => Config.proxy_port || nil
       }
       api = Api.new
       res = api.request(opts)


### PR DESCRIPTION
This change adds two new settings, proxy_address and proxy_port, to the
settings.rb file. If they are present, then all requests will go through the
specified http proxy. If they aren't present, then no proxy is used. The
http_proxy environment variable is still respected if no proxy is specified in
the config file.
