### PR TITLE
Don't emit the event count if in the json format

### DIFF
--- a/lib/sensu-cli/base.rb
+++ b/lib/sensu-cli/base.rb
@@ -58,7 +58,7 @@ module SensuCli
       else
         Pretty.print(msg)
       end
-      Pretty.count(msg) unless @cli[:fields][:format] == 'table'
+      Pretty.count(msg) unless @cli[:fields][:format] == 'table' or @cli[:fields][:format] == 'json'
     end
 
   end


### PR DESCRIPTION
I often use this tool to get the JSON out, but I always have to "grep -v" the event count.

The json output should output pure json.

```
$ sensu-cli event list -f json | jq .
......
  }
]
parse error: Invalid numeric literal at line 341, column 2
```
