### PR TITLE
Allow silence source to be recorded

### DIFF
--- a/lib/sensu-cli/cli.rb
+++ b/lib/sensu-cli/cli.rb
@@ -296,6 +296,7 @@ module SensuCli
         opt :owner, 'The owner of the stash', :short => 'o', :type => :string
         opt :reason, 'The reason this check/node is being silenced', :short => 'r', :type => :string
         opt :expire, 'The number of seconds the silenced event is valid', :short => 'e', :type => :integer
+        opt :source, 'The name of the source of the silence', :short => 's', :type => :string
       end
       command = next_argv
       explode(opts) if command.nil?

--- a/lib/sensu-cli/cli.rb
+++ b/lib/sensu-cli/cli.rb
@@ -296,7 +296,7 @@ module SensuCli
         opt :owner, 'The owner of the stash', :short => 'o', :type => :string
         opt :reason, 'The reason this check/node is being silenced', :short => 'r', :type => :string
         opt :expire, 'The number of seconds the silenced event is valid', :short => 'e', :type => :integer
-        opt :source, 'The name of the source of the silence', :short => 's', :type => :string
+        opt :source, 'The name of the source of the silence', :short => 's', :type => :string, :default => 'sensu-cli'
       end
       command = next_argv
       explode(opts) if command.nil?

--- a/lib/sensu-cli/path.rb
+++ b/lib/sensu-cli/path.rb
@@ -58,7 +58,7 @@ module SensuCli
       content = { :timestamp => Time.now.to_i }
       content.merge!(:owner => cli[:fields][:owner]) if cli[:fields][:owner]
       content.merge!(:reason => cli[:fields][:reason]) if cli[:fields][:reason]
-      content.merge!(:reason => cli[:fields][:source]) if cli[:fields][:source]
+      content.merge!(:source => cli[:fields][:source]) if cli[:fields][:source]
       payload = { :content =>  content }
       payload.merge!(:expire => cli[:fields][:expire].to_i) if cli[:fields][:expire]
       silence_path = 'silence'

--- a/lib/sensu-cli/path.rb
+++ b/lib/sensu-cli/path.rb
@@ -58,6 +58,7 @@ module SensuCli
       content = { :timestamp => Time.now.to_i }
       content.merge!(:owner => cli[:fields][:owner]) if cli[:fields][:owner]
       content.merge!(:reason => cli[:fields][:reason]) if cli[:fields][:reason]
+      content.merge!(:reason => cli[:fields][:source]) if cli[:fields][:source]
       payload = { :content =>  content }
       payload.merge!(:expire => cli[:fields][:expire].to_i) if cli[:fields][:expire]
       silence_path = 'silence'

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -200,19 +200,19 @@ describe 'SensuCli::Cli' do
     it 'should return silence node hash' do
       ARGV.push('silence', 'test_node')
       response = @cli.global
-      response.should eq(:command => 'silence', :method => 'Post', :fields => { :client => 'test_node', :check => nil, :owner => nil, :reason => nil, :expire =>  nil, :help => false })
+      response.should eq(:command => 'silence', :method => 'Post', :fields => { :client => 'test_node', :check => nil, :owner => nil, :reason => nil, :expire =>  nil, :source => nil, :help => false })
     end
 
     it 'should return silence node check hash' do
       ARGV.push('silence', 'test_node', '-k', 'test_check')
       response = @cli.global
-      response.should eq(:command => 'silence', :method => 'Post', :fields => { :client => 'test_node', :check => 'test_check', :owner => nil, :reason => nil, :expire =>  nil, :help => false, :check_given => true })
+      response.should eq(:command => 'silence', :method => 'Post', :fields => { :client => 'test_node', :check => 'test_check', :owner => nil, :reason => nil, :expire =>  nil, :source => nil, :help => false, :check_given => true })
     end
 
     it 'should return silence node check hash with options' do
-      ARGV.push('silence', 'test_node', '-k', 'test_check', '-r', "it's noisy", '-e', '30')
+      ARGV.push('silence', 'test_node', '-k', 'test_check', '-r', "it's noisy", '-e', '30', '-s', 'sensu-cli')
       response = @cli.global
-      response.should eq(:command => 'silence', :method => 'Post', :fields => { :client => 'test_node', :check => 'test_check', :owner => nil, :reason => "it's noisy", :expire => 30, :help => false, :check_given => true, :reason_given => true, :expire_given => true })
+      response.should eq(:command => 'silence', :method => 'Post', :fields => { :client => 'test_node', :check => 'test_check', :owner => nil, :reason => "it's noisy", :expire => 30, :source => 'sensu-cli', :help => false, :check_given => true, :reason_given => true, :expire_given => true, :source_given => true })
     end
 
   end


### PR DESCRIPTION
This allows the user to add a message to define where a check was silenced. This can be useful to record that it was the dashboard, or the cli. This ties into https://github.com/sensu/uchiwa/pull/158
