### PR TITLE
Use 1.8 compatible rainbow gem

### DIFF
--- a/sensu-cli.gemspec
+++ b/sensu-cli.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.licenses    = %w(MIT APACHE)
   s.homepage    = 'http://github.com/agent462/sensu-cli'
 
-  s.add_dependency('rainbow', '2.0.0')
+  s.add_dependency('rainbow', '1.99.2')
   s.add_dependency('trollop', '2.0')
   s.add_dependency('mixlib-config', '2.1.0')
   s.add_dependency('hirb', '0.7.1')


### PR DESCRIPTION
Rainbow 2.0.0 explicitly breaks 1.8 ruby builds, whilst 1.99.2 provides the same functionality as 2.0, whilst preserving 1.8 compatibility.

Normally this wouldn't be that much of an issue, except that RHEL are stuck on ruby 1.8 for another couple of years. 

This patch is a simple one-liner than changes the required rainbow version to 1.99.2, which works on all (as far as I can see) active versions of ruby in the wild. 