### PR TITLE
Relax requirements for mixlib-config

### DIFF
--- a/sensu-cli.gemspec
+++ b/sensu-cli.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('rainbow', '1.99.2')
   s.add_dependency('trollop', '2.0')
-  s.add_dependency('mixlib-config', '2.1.0')
+  s.add_dependency('mixlib-config', '>=2.1.0')
   s.add_dependency('hirb', '0.7.1')
   s.add_dependency('erubis', '2.7.0')
 


### PR DESCRIPTION
Sensu 0.19.0 no longer ships with mixlib-config 2.1.0. Instead, it has 2.2.0. This allows 2.1.0 or greater to be used.