### PR TITLE
Allow for higher versions of all gems

### DIFF
--- a/sensu-cli.gemspec
+++ b/sensu-cli.gemspec
@@ -12,11 +12,11 @@ Gem::Specification.new do |s|
   s.licenses    = %w(MIT APACHE)
   s.homepage    = 'http://github.com/agent462/sensu-cli'
 
-  s.add_dependency('rainbow', '1.99.2')
-  s.add_dependency('trollop', '2.0')
+  s.add_dependency('rainbow', '>=1.99.2')
+  s.add_dependency('trollop', '>=2.0')
   s.add_dependency('mixlib-config', '>=2.1.0')
-  s.add_dependency('hirb', '0.7.1')
-  s.add_dependency('erubis', '2.7.0')
+  s.add_dependency('hirb', '>=0.7.1')
+  s.add_dependency('erubis', '>=2.7.0')
 
   s.add_development_dependency('rspec')
   s.add_development_dependency('rubocop')


### PR DESCRIPTION
I realised that I should have added this for all gems. I've tested this on against Sensu 0.19.0, and it works.