### PR TITLE
Conditional for Rainbow

### DIFF
--- a/sensu-cli.gemspec
+++ b/sensu-cli.gemspec
@@ -12,7 +12,11 @@ Gem::Specification.new do |s|
   s.licenses    = %w(MIT APACHE)
   s.homepage    = 'http://github.com/agent462/sensu-cli'
 
-  s.add_dependency('rainbow', '1.99.2')
+  if RUBY_VERSION < '1.9'
+    s.add_dependency('rainbow', '1.99.2')
+  else
+    s.add_dependency('rainbow', '2.0.0')
+  end
   s.add_dependency('trollop', '2.0')
   s.add_dependency('mixlib-config', '2.1.0')
   s.add_dependency('hirb', '0.7.1')


### PR DESCRIPTION
https://github.com/agent462/sensu-cli/commit/b0f8466f2077fbe75742636666dd96d07aaf0652 This commit breaks compatibility with environments running old versions of sensu-cli who had rainbow 2.0.0 installed via packages instead of gem install.

This allows those people to install the newest version without installing an older version of rainbow while keeping compatibility for people running ruby < 1.9