### PR TITLE
use join to prevent multiple slashes

### DIFF
--- a/lib/sensu-cli/path.rb
+++ b/lib/sensu-cli/path.rb
@@ -90,7 +90,7 @@ module SensuCli
     end
 
     def respond(path, payload = false)
-      { :path => "#{Config.api_endpoint}#{path}", :payload => payload }
+      { :path => ::File.join(Config.api_endpoint.to_s, path), :payload => payload }
     end
   end
 end


### PR DESCRIPTION
Fixes an issue I encountered when initially setting the ``api_endpoint`` configuration to ``/``.  In this case, it would query for example ``[my.sensu]:4567//info`` and consistently return 404.  This instead uses join to formulate the api path, which handles this case.  The ``.to_s`` is necessary to handle when api_endpoint is nil.