### PR TITLE
disable pretty colors if there is not a tty

### DIFF
--- a/lib/sensu-cli/base.rb
+++ b/lib/sensu-cli/base.rb
@@ -31,7 +31,11 @@ module SensuCli
       else
         settings.create(directory, file)
       end
-      Rainbow.enabled = Config.pretty_colors == false ? false : true
+      if $stdout.isatty and not Config.pretty_colors == false
+        Rainbow.enabled = true
+      else
+        Rainbow.enabled = false
+      end
     end
 
     def api_path(cli)


### PR DESCRIPTION
the 'and not Config.pretty_colors == false' is slightly awkward, but I didn't want to change the behavior beyond automatically disabling pretty colors when the output is being piped into something other than a tty.