### PR TITLE
add human readable timestamps in event show output

### DIFF
--- a/lib/sensu-cli/templates/event.erb
+++ b/lib/sensu-cli/templates/event.erb
@@ -11,7 +11,13 @@
   <%= "interval:".color(:cyan) %> <%= check['interval'].to_s.color(:green) %>
   <%= "subscribers:".color(:cyan) %> <%= check['subscribers'].to_s.color(:green) %>
   <%= "issued:".color(:cyan) %> <%= check['issued'].to_s.color(:green) %>
+  <% if check['issued'] -%>
+  <%= "issued_s:".color(:cyan) %> <%= Time.at(check['issued']).to_s.color(:green) %>
+  <% end -%>
   <%= "executed:".color(:cyan) %> <%= check['executed'].to_s.color(:green) %>
+  <% if check['executed'] -%>
+  <%= "executed_s:".color(:cyan) %> <%= Time.at(check['executed']).to_s.color(:green) %>
+  <% end -%>
   <%= "duration:".color(:cyan) %> <%= check['duration'].to_s.color(:green) %>
   <%= "output:".color(:cyan) %> <%= check['output'].rstrip.to_s.color(:green) %>
   <%= "status:".color(:cyan) %> <%= check['status'].to_s.color(:green) %>


### PR DESCRIPTION
sensu-cli event show my_client_name

```
  issued: 1455318711
  issued_s: 2016-02-12 15:11:51 -0800
  executed: 1455318711
  executed_s: 2016-02-12 15:11:51 -0800
```