### PR TITLE
Moving to Pessimistic Version locks

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.10.0  07/31/2018
+* Moving to pessimistic version locks
+* Updating testing to pass
+* renamed helper to spec helper and using LOADPATH to require cleanly
+* updating Base#settings to take parameters and defining standards
+
 ## 0.9.0 01/18/2018
 * Add token authorization
 

--- a/lib/sensu-cli/base.rb
+++ b/lib/sensu-cli/base.rb
@@ -19,9 +19,8 @@ module SensuCli
       socket.send_udp_message
     end
 
-    def settings
-      directory = "#{Dir.home}/.sensu"
-      file = "#{directory}/settings.rb"
+    def settings(directory = "#{Dir.home}/.sensu", filename = 'settings.rb')
+      file = "#{directory}/#{filename}"
       alt = '/etc/sensu/sensu-cli/settings.rb'
       settings = Settings.new
       if settings.file?(file)

--- a/lib/sensu-cli/version.rb
+++ b/lib/sensu-cli/version.rb
@@ -1,3 +1,3 @@
 module SensuCli
-  VERSION = '0.9.0'
+  VERSION = '0.10.0'
 end

--- a/sensu-cli.gemspec
+++ b/sensu-cli.gemspec
@@ -15,12 +15,12 @@ Gem::Specification.new do |s|
   if RUBY_VERSION < '1.9'
     s.add_dependency('rainbow', '1.99.2')
   else
-    s.add_dependency('rainbow', '>=2.0.0')
+    s.add_dependency('rainbow', '~> 2.0')
   end
-  s.add_dependency('trollop', '2.0')
-  s.add_dependency('mixlib-config', '>=2.1.0')
-  s.add_dependency('hirb', '0.7.1')
-  s.add_dependency('erubis', '2.7.0')
+  s.add_dependency('trollop', '~> 2.0')
+  s.add_dependency('mixlib-config', '~> 2.1')
+  s.add_dependency('hirb', '~> 0.7')
+  s.add_dependency('erubis', '~> 2.7')
 
   s.add_development_dependency('rspec')
   s.add_development_dependency('rubocop')

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -1,5 +1,4 @@
-require File.dirname(__FILE__) + '/../lib/sensu-cli/api.rb'
-require File.dirname(__FILE__) + '/helpers.rb'
+require 'sensu-cli/api'
 
 describe 'SensuCli::Api' do
   include Helpers

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -1,5 +1,4 @@
-require File.dirname(__FILE__) + '/../lib/sensu-cli/base.rb'
-require File.dirname(__FILE__) + '/helpers.rb'
+require 'sensu-cli/base'
 require 'json'
 
 describe 'SensuCli::Base' do
@@ -229,8 +228,9 @@ describe 'SensuCli::Base' do
   end
 
   describe 'settings' do
+
     it 'can setup settings' do
-      @core.settings
+      @core.settings('./spec/settings')
       SensuCli::Config.host.should match(/^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/)
       SensuCli::Config.port.should eq('4567')
       SensuCli::Config.ssl.should satisfy { true || false }

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1,5 +1,4 @@
-require File.dirname(__FILE__) + '/../lib/sensu-cli/cli.rb'
-require File.dirname(__FILE__) + '/helpers.rb'
+require 'sensu-cli/cli'
 
 describe 'SensuCli::Cli' do
   include Helpers
@@ -200,13 +199,13 @@ describe 'SensuCli::Cli' do
     it 'should return silence node hash' do
       ARGV.push('silence', 'test_node')
       response = @cli.global
-      response.should eq(:command => 'silence', :method => 'Post', :fields => { :client => 'test_node', :check => nil, :owner => nil, :reason => nil, :expire =>  nil, :source => nil, :help => false })
+      response.should eq(:command => 'silence', :method => 'Post', :fields => { :client => 'test_node', :check => nil, :owner => nil, :reason => nil, :expire =>  nil, :source => 'sensu-cli', :help => false })
     end
 
     it 'should return silence node check hash' do
       ARGV.push('silence', 'test_node', '-k', 'test_check')
       response = @cli.global
-      response.should eq(:command => 'silence', :method => 'Post', :fields => { :client => 'test_node', :check => 'test_check', :owner => nil, :reason => nil, :expire =>  nil, :source => nil, :help => false, :check_given => true })
+      response.should eq(:command => 'silence', :method => 'Post', :fields => { :client => 'test_node', :check => 'test_check', :owner => nil, :reason => nil, :expire =>  nil, :source => 'sensu-cli', :help => false, :check_given => true })
     end
 
     it 'should return silence node check hash with options' do

--- a/spec/path_spec.rb
+++ b/spec/path_spec.rb
@@ -1,5 +1,4 @@
-require File.dirname(__FILE__) + '/../lib/sensu-cli/path.rb'
-require File.dirname(__FILE__) + '/helpers.rb'
+require 'sensu-cli/path'
 
 describe 'SensuCli::PathParser' do
   include Helpers

--- a/spec/pretty_spec.rb
+++ b/spec/pretty_spec.rb
@@ -1,5 +1,4 @@
-require File.dirname(__FILE__) + '/../lib/sensu-cli/pretty.rb'
-require File.dirname(__FILE__) + '/helpers.rb'
+require 'sensu-cli/pretty'
 require 'json'
 
 describe 'SensuCli::Pretty' do

--- a/spec/settings_spec.rb
+++ b/spec/settings_spec.rb
@@ -1,5 +1,5 @@
-require File.dirname(__FILE__) + '/../lib/sensu-cli.rb'
-require File.dirname(__FILE__) + '/../lib/sensu-cli/settings.rb'
+require 'sensu-cli'
+require 'sensu-cli/settings'
 
 describe 'SensuCli::Settings' do
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 require 'rspec'
 
+$LOAD_PATH << '../lib'
+
 module Helpers
   def capture_stdout(*)
     original_stdout = $stdout


### PR DESCRIPTION
Changing to pessimistic locks to allow better inclusion into Gemfiles

Updating Base#settings to allow path and file name, with allows non-standard locations as well as file stubbing in tests.

Updating spec to automatically include spec_helper through .rspec, and using LOAD_PATH to not have to path_munge in the tests.

```
Finished in 0.05635 seconds (files took 0.2681 seconds to load)
92 examples, 0 failures
```