### PR TITLE
sensu-cli.bash: make the bash completion more robust

### DIFF
--- a/contrib/sensu-cli.bash
+++ b/contrib/sensu-cli.bash
@@ -6,16 +6,16 @@
 # . /etc/bash_completion
 #
 _sensu_clients() {
-  sensu-cli client list | grep name | cut -f 2 -d : | xargs
+  sensu-cli client list | grep ^name: | cut -f 2- -d : | xargs
 }
 _sensu_checks() {
-  sensu-cli check list | grep name | cut -f 2 -d : | xargs
+  sensu-cli check list | grep ^name: | cut -f 2- -d : | xargs
 }
 _sensu_stashes() {
-  sensu-cli stash list | grep path | cut -f 2 -d : | xargs
+  sensu-cli stash list | grep ^path: | cut -f 2- -d : | xargs
 }
 _sensu_aggregates() {
-  sensu-cli aggregate list | grep check | cut -f 2 -d : | xargs
+  sensu-cli aggregate list | grep ^check: | cut -f 2- -d : | xargs
 }
 
 _sensu-cli() {


### PR DESCRIPTION
* Anchor regular expressions. This will prevent accidentally matching
the wrong fields.
* Make "cut -f" take a range of fields from field 2 to the end of the
line. This is necessary for silenced ids, subscriptions and clients that
can contain ":".